### PR TITLE
fix improper children passthrough and add withClient

### DIFF
--- a/app/clientOnly.tsx
+++ b/app/clientOnly.tsx
@@ -2,11 +2,11 @@
 
 // Imports
 // ========================================================
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 
 // Page
 // ========================================================
-export default function ClientOnly({ children }: { children: React.ReactNode }) {
+export default function ClientOnly({ children }: { children: JSX.Element | null }) {
     // State / Props
     const [hasMounted, setHasMounted] = useState(false);
 
@@ -18,9 +18,16 @@ export default function ClientOnly({ children }: { children: React.ReactNode }) 
     // Render
     if (!hasMounted) return null;
 
-    return (
-        <div>
-            {children}
-        </div>
-    );
+    return children
 };
+
+export const withClient = (Component: () => JSX.Element) => {
+    const element = () => (
+        <ClientOnly>
+            <Component />
+        </ClientOnly>
+    );
+    element.displayName = 'ClientOnly';
+    return element;
+};
+


### PR DESCRIPTION
This PR does two things-

1. Instead of [creating a new `div`](https://github.com/codingwithmanny/next13-wagmi-hydration/blob/aa5c7374178f5e31fb03cd3bf32d54041378de69/app/clientOnly.tsx#L21-L25) element, it just passes the children along. This helps with things like preserving styles of parent elements.
2. It provides a `withClient` helper method so instead of using the `<ClientOnly>` component, you can just export your entire component like so: `export default withClient(MyComponent)`.